### PR TITLE
Fix c style syntax

### DIFF
--- a/src/harud/types.d
+++ b/src/harud/types.d
@@ -107,7 +107,7 @@ struct TextWidth {
 }
 
 struct DashMode {
-   ushort ptn[8];
+   ushort[8] ptn;
    uint numPtn;
    uint phase;
 }


### PR DESCRIPTION
Change of array syntax to D-style to fix compiling in DMD 2.067 and above
